### PR TITLE
bump libei1.4 and libportal0.9

### DIFF
--- a/org.deskflow.deskflow.yml
+++ b/org.deskflow.deskflow.yml
@@ -57,8 +57,8 @@ modules:
     sources:
         - type: git
           url: https://gitlab.freedesktop.org/libinput/libei
-          tag: 1.3.0
-          commit: 997b7c0f37faea4f8bae59613c8f27370925d5b0
+          tag: 1.4.0
+          commit: 5d6d8e6590df210b75559a889baa9459c68d9366
   - name: libportal
     buildsystem: meson
     config-opts:
@@ -70,8 +70,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/flatpak/libportal.git
-        tag: 0.8.1
-        commit: 26c15008cbe579f57f89468384f8efc033f25f6f
+        tag: 0.9.1
+        commit: 8f5dc8d192f6e31dafe69e35219e3b707bde71ce
   - name: puixml
     buildsystem: cmake-ninja
     sources:
@@ -114,4 +114,3 @@ modules:
         url: https://github.com/deskflow/deskflow.git
         tag: v1.20.0
         commit: 3ef5793beb52e1e6cb37c2255c649eaf7626046c
-


### PR DESCRIPTION
bump depends 
 - libei 1.4.0 
 - libportal 0.9.1