### PR TITLE
update depends use kde/platform 6.9 cli11 2.5.0 and libei 1.4.1

### DIFF
--- a/libportal-qt69.patch
+++ b/libportal-qt69.patch
@@ -1,0 +1,41 @@
+From 796053d2eebe4532aad6bd3fd80cdf3b197806ec Mon Sep 17 00:00:00 2001
+From: Jan Grulich <jgrulich@redhat.com>
+Date: Thu, 27 Mar 2025 09:38:10 +0100
+Subject: [PATCH] qt6: fix build against Qt 6.9+
+
+QGenericUnixServices was renamed to QDesktopUnixServices in Qt 6.9.
+
+Upstream change: https://codereview.qt-project.org/c/qt/qtbase/+/609639
+---
+ libportal/portal-qt6.cpp | 8 ++++++++
+ 1 file changed, 8 insertions(+)
+
+diff --git a/libportal/portal-qt6.cpp b/libportal/portal-qt6.cpp
+index d38a4e30..34f0d72a 100644
+--- a/libportal/portal-qt6.cpp
++++ b/libportal/portal-qt6.cpp
+@@ -31,8 +31,12 @@
+ #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
+ #include <qpa/qplatformintegration.h>
+ #include <private/qguiapplication_p.h>
++#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
++#include <private/qdesktopunixservices_p.h>
++#else
+ #include <private/qgenericunixservices_p.h>
+ #endif
++#endif
+ 
+ static gboolean
+ _xdp_parent_export_qt (XdpParent *parent,
+@@ -45,7 +49,11 @@ _xdp_parent_export_qt (XdpParent *parent,
+   }
+ 
+ #if QT_VERSION >= QT_VERSION_CHECK(6, 5, 0)
++#if QT_VERSION >= QT_VERSION_CHECK(6, 9, 0)
++  if (const auto services = dynamic_cast<QDesktopUnixServices*>(QGuiApplicationPrivate::platformIntegration()->services()))
++#else
+   if (const auto services = dynamic_cast<QGenericUnixServices*>(QGuiApplicationPrivate::platformIntegration()->services()))
++#endif
+     {
+       g_autofree char *handle = g_strdup(services->portalWindowIdentifier(w).toUtf8().constData());
+ 

--- a/org.deskflow.deskflow.yml
+++ b/org.deskflow.deskflow.yml
@@ -1,6 +1,6 @@
 app-id: org.deskflow.deskflow
 runtime: org.kde.Platform
-runtime-version: "6.8"
+runtime-version: "6.9"
 sdk: org.kde.Sdk
 command: deskflow
 finish-args:
@@ -46,8 +46,8 @@ modules:
     sources:
         - type: git
           url: https://gitlab.freedesktop.org/libinput/libei
-          tag: 1.4.0
-          commit: 5d6d8e6590df210b75559a889baa9459c68d9366
+          tag: 1.4.1
+          commit: 9e0413cbc7d3ae6656266890425f152589ddf74d
   - name: libportal
     buildsystem: meson
     config-opts:
@@ -61,6 +61,8 @@ modules:
         url: https://github.com/flatpak/libportal.git
         tag: 0.9.1
         commit: 8f5dc8d192f6e31dafe69e35219e3b707bde71ce
+      - type: patch
+        path: libportal-qt69.patch
   - name: cli11
     buildsystem: cmake-ninja
     config-opts:
@@ -68,8 +70,8 @@ modules:
     sources:
       - type: git
         url: https://github.com/CLIUtils/CLI11
-        tag: v2.4.2
-        commit: 6c7b07a878ad834957b98d0f9ce1dbe0cb204fc9
+        tag: v2.5.0
+        commit: 4160d259d961cd393fd8d67590a8c7d210207348
   - name: tomlplusplus
     buildsystem: cmake-ninja
     sources:


### PR DESCRIPTION
- CLI11 updated to 2.5.0 in flatpak recipe and if we need to pull it during build time
- Use KDEPlatform 6.9 when building the flatpak
  -  Added a patch for libportal to fix building on Qt 6.9+
  -  Remove the patch when libportal gets a new release
- LibEI upated to 1.4.1 when building the flatpak

Matches: https://github.com/deskflow/deskflow/pull/8635